### PR TITLE
Hotfix from renaming from NBT DataflawlessClothing to clothing

### DIFF
--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
@@ -126,7 +126,7 @@ public class Flawless extends SparklemoonFamily implements IShearable {
 	@Override
 	public void readAdditionalSaveData(CompoundTag compound) {
 		super.readAdditionalSaveData(compound);
-		this.entityData.set(DATA_CLOTHING, compound.getString("DataflawlessClothing"));
+		this.entityData.set(DATA_CLOTHING, compound.getString("clothing"));
 	}
 
 	@Override


### PR DESCRIPTION
Setting Flawless's clothes from the summon command did not work as expected (no clothing from her.)