### PR TITLE
Fix Flawless from losing her clothes visually but not from her effect…

### DIFF
--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
@@ -231,8 +231,10 @@ public class Flawless extends TamableTamersPony implements Shearable {
 
     @Override
     public ItemEntity spawnAtLocation(ItemStack drop, float offsetY) {
-        this.setClothing(Clothing.NONE);
-        this.offClothing((FlawlessClothingItem) drop.getItem());
+        if (drop.getItem() instanceof FlawlessClothingItem flawlessClothingItem) {
+            this.setClothing(Clothing.NONE);
+            this.offClothing(flawlessClothingItem);
+        }
         return super.spawnAtLocation(drop, offsetY);
     }
 


### PR DESCRIPTION
This happens because I never checked if the dropping item is a lead by doing `instanceof`. I did not know that `spawnAtLocation(ItemStack, float)` would be called by the mechanic of the leash in `Mob.tickLeash()`.

Closes #58.