### PR TITLE
Fix Flawless unequippable clothing when spawned using `/summon` with NBT

### DIFF
--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
@@ -138,7 +138,10 @@ public class Flawless extends TamableTamersPony implements Shearable {
 	@Override
 	public void readAdditionalSaveData(CompoundTag compound) {
 		super.readAdditionalSaveData(compound);
-		this.entityData.set(DATA_CLOTHING, compound.getString("clothing"));
+
+        if (compound.contains("clothing")) {
+            this.entityData.set(DATA_CLOTHING, compound.getString("clothing"));
+        }
 	}
 
 	@Override


### PR DESCRIPTION
When you spawn a Flawless spawns using the following command: `/summon minelittleflawless:flawless ~ ~ ~ {Age:-24000}`

Closes #68.