### PR TITLE
Fix pony parts that are not being shown when using `/summon`

### DIFF
--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Arinos.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Arinos.java
@@ -1,10 +1,8 @@
 package org.projectflawless.minelittleflawless.entity;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.goal.TemptGoal;
@@ -13,15 +11,14 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
-import org.jetbrains.annotations.Nullable;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 
 public class Arinos extends TamableTamersPony {
     public Arinos(EntityType<Arinos> type, Level world) {
         super(type, world);
+        this.setAlicorn(true);
     }
 
     @Override
@@ -48,12 +45,6 @@ public class Arinos extends TamableTamersPony {
     @Override
     public boolean canAttackType(EntityType<?> entityType) {
         return !this.getType().equals(entityType);
-    }
-
-    @Override
-    public SpawnGroupData finalizeSpawn(ServerLevelAccessor world, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData livingdata, @Nullable CompoundTag dataTag) {
-        this.setAlicorn(true);
-        return super.finalizeSpawn(world, difficulty, spawnType, livingdata, dataTag);
     }
 
     @Override

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
@@ -56,7 +56,8 @@ public class Flawless extends TamableTamersPony implements Shearable {
 		xpReward = 0;
 		setNoAi(false);
         this.setGuaranteedDrop(EquipmentSlot.CHEST);
-	}
+        this.setUnicorn(true);
+    }
 
 	@Override
 	protected void defineSynchedData() {
@@ -108,8 +109,6 @@ public class Flawless extends TamableTamersPony implements Shearable {
 
 	@Override
 	public SpawnGroupData finalizeSpawn(ServerLevelAccessor world, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData livingdata, @Nullable CompoundTag dataTag) {
-        this.setUnicorn(true);
-
 		SpawnGroupData retval = super.finalizeSpawn(world, difficulty, spawnType, livingdata, dataTag);
 
         ResourceLocation flawlessClothing;

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/StarCatcher.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/StarCatcher.java
@@ -1,11 +1,11 @@
 package org.projectflawless.minelittleflawless.entity;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleContainer;
@@ -23,7 +23,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.ServerLevelAccessor;
 import net.tslat.smartbrainlib.api.SmartBrainOwner;
 import net.tslat.smartbrainlib.api.core.BrainActivityGroup;
 import net.tslat.smartbrainlib.api.core.SmartBrainProvider;
@@ -49,6 +48,7 @@ public class StarCatcher extends TamableTamersPony implements InventoryCarrier, 
     
     public StarCatcher(EntityType<StarCatcher> type, Level world) {
         super(type, world);
+        this.setPegasus(true);
     }
 
     @Override
@@ -161,12 +161,6 @@ public class StarCatcher extends TamableTamersPony implements InventoryCarrier, 
     @Override
     protected @Nullable SoundEvent getDeathSound() {
         return MineLittleFlawlessSoundEvents.STAR_CATCHER_DEATH;
-    }
-
-    @Override
-    public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType reason, @Nullable SpawnGroupData spawnData, @Nullable CompoundTag dataTag) {
-        this.setPegasus(true);
-        return super.finalizeSpawn(level, difficulty, reason, spawnData, dataTag);
     }
 
     @Override

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/TamableTamersPony.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/TamableTamersPony.java
@@ -77,10 +77,12 @@ public abstract class TamableTamersPony extends TamableAnimal implements GeoEnti
     public void readAdditionalSaveData(CompoundTag compound) {
         super.readAdditionalSaveData(compound);
 
-        CompoundTag ponyData = compound.getCompound("PonyData");
-        this.setStallion(ponyData.getBoolean("Stallion"));
-        this.setUnicorn(ponyData.getBoolean("Unicorn"));
-        this.setPegasus(ponyData.getBoolean("Pegasus"));
+        if (compound.contains("PonyData")) {
+            CompoundTag ponyData = compound.getCompound("PonyData");
+            this.setStallion(ponyData.getBoolean("Stallion"));
+            this.setUnicorn(ponyData.getBoolean("Unicorn"));
+            this.setPegasus(ponyData.getBoolean("Pegasus"));
+        }
     }
 
     public boolean isStallion() {

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Trixie.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Trixie.java
@@ -1,9 +1,7 @@
 package org.projectflawless.minelittleflawless.entity;
 
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.goal.*;
@@ -12,8 +10,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.ServerLevelAccessor;
-import org.jetbrains.annotations.Nullable;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
@@ -21,6 +17,7 @@ import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
 public class Trixie extends TamableTamersPony {
     public Trixie(EntityType<Trixie> type, Level world) {
         super(type, world);
+        this.setUnicorn(true);
     }
 
     @Override
@@ -47,12 +44,6 @@ public class Trixie extends TamableTamersPony {
     @Override
     public SoundEvent getDeathSound() {
         return MineLittleFlawlessSoundEvents.TRIXIE_DEATH;
-    }
-
-    @Override
-    public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType reason, @Nullable SpawnGroupData spawnData, @Nullable CompoundTag dataTag) {
-        this.setUnicorn(true);
-        return super.finalizeSpawn(level, difficulty, reason, spawnData, dataTag);
     }
 
     @Override

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Trixiebelle.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Trixiebelle.java
@@ -1,20 +1,16 @@
 package org.projectflawless.minelittleflawless.entity;
 
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobSpawnType;
-import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.ai.goal.TemptGoal;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.ServerLevelAccessor;
 import org.jetbrains.annotations.Nullable;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
@@ -22,6 +18,7 @@ import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents
 public class Trixiebelle extends TamableTamersPony {
     public Trixiebelle(EntityType<Trixiebelle> type, Level world) {
         super(type, world);
+        this.setUnicorn(true);
     }
 
     @Override
@@ -48,12 +45,6 @@ public class Trixiebelle extends TamableTamersPony {
     @Override
     protected @Nullable SoundEvent getDeathSound() {
         return MineLittleFlawlessSoundEvents.TRIXIEBELLE_DEATH;
-    }
-
-    @Override
-    public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType reason, @Nullable SpawnGroupData spawnData, @Nullable CompoundTag dataTag) {
-        this.setUnicorn(true);
-        return super.finalizeSpawn(level, difficulty, reason, spawnData, dataTag);
     }
 
     @Override

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Twilight.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Twilight.java
@@ -1,9 +1,7 @@
 package org.projectflawless.minelittleflawless.entity;
 
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.goal.*;
@@ -12,8 +10,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.ServerLevelAccessor;
-import org.jetbrains.annotations.Nullable;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
@@ -21,6 +17,7 @@ import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
 public class Twilight extends TamableTamersPony {
     public Twilight(EntityType<Twilight> type, Level world) {
         super(type, world);
+        this.setUnicorn(true);
     }
 
     @Override
@@ -47,12 +44,6 @@ public class Twilight extends TamableTamersPony {
     @Override
     public SoundEvent getDeathSound() {
         return MineLittleFlawlessSoundEvents.TWILIGHT_DEATH;
-    }
-
-    @Override
-    public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType reason, @Nullable SpawnGroupData spawnData, @Nullable CompoundTag dataTag) {
-        this.setUnicorn(true);
-        return super.finalizeSpawn(level, difficulty, reason, spawnData, dataTag);
     }
 
     @Override


### PR DESCRIPTION
Apparently, when you type the `/summon` command with any entity of this mob with NBT, it doesn't call the respective `finalizeSpawn` method if that's only being used, only for naturally spawned and egged mobs.

I moved these set methods to the constructor of each mob, and deleted some of the `finalizeSpawn`s of some mob that merely have those set functions and called `super.finalizeSpawn`.

I also placed an if condition on `TamableTamersPony.readAdditionalSaveData` that checks if a compound NBT called `PonyData` is there. If it is, it should set the appropriate values that would make the pony parts reappear.

This part was a bug that I left out at commit 45126174f6dc9202d3cc18c17ebade06f3a14480.

Closes issue #70.