### PR TITLE
Add raid handling for tamed ponies

### DIFF
--- a/src/main/java/org/projectflawless/minelittleflawless/FlawlessEvents.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/FlawlessEvents.java
@@ -1,9 +1,18 @@
 package org.projectflawless.minelittleflawless;
 
 import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+import net.minecraft.util.Mth;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.raid.Raid;
+import net.minecraft.world.entity.raid.Raider;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameRules;
 import org.projectflawless.minelittleflawless.entity.Flawless;
 import org.projectflawless.minelittleflawless.entity.TamableTamersPony;
 
@@ -21,6 +30,43 @@ public class FlawlessEvents {
                     entity.setLastHurtByPlayer(player);
             }
             return true;
+        });
+
+        // This allows tamed ponies to give the player bad omen if the raider they killed is a captain.
+        // It also allows them to give you the Hero of the Village.
+        ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.register((serverLevel, entity, killedEntity) -> {
+            if (killedEntity instanceof Raider raider) {
+                if (entity instanceof TamableTamersPony tamersPony && tamersPony.isTame()) {
+                    if (tamersPony.getOwner() instanceof Player player) {
+                        Raid raid = serverLevel.getRaidAt(killedEntity.blockPosition());
+
+                        if (raid != null) {
+                            raid.addHeroOfTheVillage(player);
+                        }
+
+                        if (raider.isPatrolLeader() && raid == null && serverLevel.getRaidAt(raider.blockPosition()) == null) {
+                            ItemStack itemStack = raider.getItemBySlot(EquipmentSlot.HEAD);
+
+                            if (!itemStack.isEmpty() && ItemStack.matches(itemStack, Raid.getLeaderBannerInstance())) {
+                                MobEffectInstance mobEffectInstance = player.getEffect(MobEffects.BAD_OMEN);
+                                int i = 1;
+                                if (mobEffectInstance != null) {
+                                    i += mobEffectInstance.getAmplifier();
+                                    player.removeEffectNoUpdate(MobEffects.BAD_OMEN);
+                                } else {
+                                    i--;
+                                }
+
+                                i = Mth.clamp(i, 0, 4);
+                                MobEffectInstance mobEffectInstance2 = new MobEffectInstance(MobEffects.BAD_OMEN, 120000, i, false, false, true);
+                                if (!raider.level().getGameRules().getBoolean(GameRules.RULE_DISABLE_RAIDS)) {
+                                    player.addEffect(mobEffectInstance2);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         });
     }
 }

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/TamableTamersPony.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/TamableTamersPony.java
@@ -18,6 +18,7 @@ import net.minecraft.world.entity.ai.goal.target.OwnerHurtByTargetGoal;
 import net.minecraft.world.entity.ai.goal.target.OwnerHurtTargetGoal;
 import net.minecraft.world.entity.monster.Enemy;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.raid.Raider;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -124,7 +125,14 @@ public abstract class TamableTamersPony extends TamableAnimal implements GeoEnti
         this.goalSelector.addGoal(1, new BreedGoal(this, 1, TamableTamersPony.class));
         this.goalSelector.addGoal(2, new OwnerHurtByTargetGoal(this));
         this.targetSelector.addGoal(3, new OwnerHurtTargetGoal(this));
-        this.targetSelector.addGoal(4, new NearestAttackableTargetGoal<>(this, LivingEntity.class, false, targetPredicate -> targetPredicate instanceof Enemy));
+        // A compromise when non-tamed ponies shouldn't attack raiders during raids to make the Hero of the Village
+        // advancement possible, as written in FlawlessEvents:init()
+        this.targetSelector.addGoal(4, new NearestAttackableTargetGoal<>(this, LivingEntity.class, false, targetPredicate -> {
+            if (targetPredicate instanceof Raider raider && raider.getCurrentRaid() != null && !this.isTame())
+                return false;
+            else
+                return targetPredicate instanceof Enemy;
+        }));
         this.goalSelector.addGoal(5, new MeleeAttackGoal(this, 1.2, false));
         this.goalSelector.addGoal(6, new LookAtPlayerGoal(this, Player.class, (float) 6));
         this.goalSelector.addGoal(7, new FollowParentGoal(this, 1));


### PR DESCRIPTION
## [Add raid handling capabilities for tamed ponies](https://github.com/SymphonyDawn3/MineLittleFlawless/commit/228eb18d586067700e3670470e9cb95a2220fa72)

If a tamed pony kills a pillager captain, it will give the player the Bad Omen effect up to level 5 (like the vanilla).

Also, during a raid, once a tamed pony kills the last raider, the Hero of the Village advancement will be awarded to the player.

## [Change non-tamed pony attacking behavior for raiders](https://github.com/SymphonyDawn3/MineLittleFlawless/commit/fc3ddb31c9894e19188a0fcfa15a0af4422568a3)

A compromise when non-tamed ponies shouldn't attack raiders during raids to make the Hero of the Village advancement possible, as written in `FlawlessEvents:init()`.

Closes #76.