### PR TITLE
Add Trixie clothing and refactor NBT clothing to all ponies

### DIFF
--- a/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieBlackMagicianModel.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieBlackMagicianModel.java
@@ -1,0 +1,18 @@
+package org.projectflawless.minelittleflawless.client.model.entity.clothing;
+
+import net.minecraft.resources.ResourceLocation;
+import org.projectflawless.minelittleflawless.MineLittleFlawless;
+import org.projectflawless.minelittleflawless.client.model.entity.AdultAndBabyPonyModel;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+
+public class TrixieBlackMagicianModel extends AdultAndBabyPonyModel<Trixie> {
+    @Override
+    public ResourceLocation getModelResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "geo/clothing/trixie_black_magician.geo.json");
+    }
+
+    @Override
+    public ResourceLocation getTextureResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "textures/entities/clothing/trixie_black_magician.png");
+    }
+}

--- a/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieGirModel.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieGirModel.java
@@ -1,0 +1,18 @@
+package org.projectflawless.minelittleflawless.client.model.entity.clothing;
+
+import net.minecraft.resources.ResourceLocation;
+import org.projectflawless.minelittleflawless.MineLittleFlawless;
+import org.projectflawless.minelittleflawless.client.model.entity.AdultAndBabyPonyModel;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+
+public class TrixieGirModel extends AdultAndBabyPonyModel<Trixie> {
+    @Override
+    public ResourceLocation getModelResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "geo/clothing/trixie_gir.geo.json");
+    }
+
+    @Override
+    public ResourceLocation getTextureResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "textures/entities/clothing/trixie_gir.png");
+    }
+}

--- a/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieMagicianModel.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieMagicianModel.java
@@ -1,0 +1,18 @@
+package org.projectflawless.minelittleflawless.client.model.entity.clothing;
+
+import net.minecraft.resources.ResourceLocation;
+import org.projectflawless.minelittleflawless.MineLittleFlawless;
+import org.projectflawless.minelittleflawless.client.model.entity.AdultAndBabyPonyModel;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+
+public class TrixieMagicianModel extends AdultAndBabyPonyModel<Trixie> {
+    @Override
+    public ResourceLocation getModelResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "geo/clothing/trixie_magician.geo.json");
+    }
+
+    @Override
+    public ResourceLocation getTextureResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "textures/entities/clothing/trixie_magician.png");
+    }
+}

--- a/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieSchoolgirlModel.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/model/entity/clothing/TrixieSchoolgirlModel.java
@@ -1,0 +1,18 @@
+package org.projectflawless.minelittleflawless.client.model.entity.clothing;
+
+import net.minecraft.resources.ResourceLocation;
+import org.projectflawless.minelittleflawless.MineLittleFlawless;
+import org.projectflawless.minelittleflawless.client.model.entity.AdultAndBabyPonyModel;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+
+public class TrixieSchoolgirlModel extends AdultAndBabyPonyModel<Trixie> {
+    @Override
+    public ResourceLocation getModelResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "geo/clothing/trixie_schoolgirl.geo.json");
+    }
+
+    @Override
+    public ResourceLocation getTextureResource(Trixie animatable) {
+        return ResourceLocation.tryBuild(MineLittleFlawless.MOD_ID, "textures/entities/clothing/trixie_schoolgirl.png");
+    }
+}

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/TrixieRenderer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/TrixieRenderer.java
@@ -2,10 +2,18 @@ package org.projectflawless.minelittleflawless.client.renderer.entity;
 
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import org.projectflawless.minelittleflawless.client.model.entity.TrixieModel;
+import org.projectflawless.minelittleflawless.client.renderer.entity.layers.TrixieBlackMagicianLayer;
+import org.projectflawless.minelittleflawless.client.renderer.entity.layers.TrixieGirLayer;
+import org.projectflawless.minelittleflawless.client.renderer.entity.layers.TrixieMagicianLayer;
+import org.projectflawless.minelittleflawless.client.renderer.entity.layers.TrixieSchoolgirlLayer;
 import org.projectflawless.minelittleflawless.entity.Trixie;
 
 public class TrixieRenderer extends TamersPonyRenderer<Trixie, TrixieModel> {
     public TrixieRenderer(EntityRendererProvider.Context context) {
         super(context, new TrixieModel());
+        this.addRenderLayer(new TrixieMagicianLayer(this));
+        this.addRenderLayer(new TrixieBlackMagicianLayer(this));
+        this.addRenderLayer(new TrixieGirLayer(this));
+        this.addRenderLayer(new TrixieSchoolgirlLayer(this));
     }
 }

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieBlackMagicianLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieBlackMagicianLayer.java
@@ -1,0 +1,24 @@
+package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
+import org.projectflawless.minelittleflawless.client.model.entity.TrixieModel;
+import org.projectflawless.minelittleflawless.client.model.entity.clothing.TrixieBlackMagicianModel;
+import org.projectflawless.minelittleflawless.client.renderer.entity.TrixieRenderer;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+
+public class TrixieBlackMagicianLayer extends ClothingLayer<Trixie, TrixieModel> {
+    public TrixieBlackMagicianLayer(TrixieRenderer renderer) {
+        super(renderer, new TrixieBlackMagicianModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, Trixie animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.TRIXIE_BLACK_MAGICIAN))
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+    }
+}

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieGirLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieGirLayer.java
@@ -1,0 +1,24 @@
+package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
+import org.projectflawless.minelittleflawless.client.model.entity.TrixieModel;
+import org.projectflawless.minelittleflawless.client.model.entity.clothing.TrixieGirModel;
+import org.projectflawless.minelittleflawless.client.renderer.entity.TrixieRenderer;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+
+public class TrixieGirLayer extends ClothingLayer<Trixie, TrixieModel> {
+    public TrixieGirLayer(TrixieRenderer renderer) {
+        super(renderer, new TrixieGirModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, Trixie animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.TRIXIE_GIR))
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+    }
+}

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieMagicianLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieMagicianLayer.java
@@ -1,0 +1,24 @@
+package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
+import org.projectflawless.minelittleflawless.client.model.entity.TrixieModel;
+import org.projectflawless.minelittleflawless.client.model.entity.clothing.TrixieMagicianModel;
+import org.projectflawless.minelittleflawless.client.renderer.entity.TrixieRenderer;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+
+public class TrixieMagicianLayer extends ClothingLayer<Trixie, TrixieModel> {
+    public TrixieMagicianLayer(TrixieRenderer renderer) {
+        super(renderer, new TrixieMagicianModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, Trixie animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.TRIXIE_MAGICIAN))
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+    }
+}

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieSchoolgirlLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixieSchoolgirlLayer.java
@@ -1,0 +1,24 @@
+package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
+import org.projectflawless.minelittleflawless.client.model.entity.TrixieModel;
+import org.projectflawless.minelittleflawless.client.model.entity.clothing.TrixieSchoolgirlModel;
+import org.projectflawless.minelittleflawless.client.renderer.entity.TrixieRenderer;
+import org.projectflawless.minelittleflawless.entity.Trixie;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+
+public class TrixieSchoolgirlLayer extends ClothingLayer<Trixie, TrixieModel> {
+    public TrixieSchoolgirlLayer(TrixieRenderer renderer) {
+        super(renderer, new TrixieSchoolgirlModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, Trixie animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.TRIXIE_SCHOOLGIRL))
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+    }
+}

--- a/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_black_magician.geo.json
+++ b/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_black_magician.geo.json
@@ -1,0 +1,54 @@
+{
+	"format_version": "1.12.0",
+	"minecraft:geometry": [
+		{
+			"description": {
+				"identifier": "geometry.trixie_black_magician",
+				"texture_width": 128,
+				"texture_height": 128,
+				"visible_bounds_width": 3,
+				"visible_bounds_height": 4.5,
+				"visible_bounds_offset": [0, 1.75, 0]
+			},
+			"bones": [
+				{
+					"name": "body",
+					"pivot": [0, 0, 0],
+					"cubes": [
+						{"origin": [-4, 7, -9], "size": [8, 14, 16], "inflate": 0.25, "uv": [0, 0]},
+						{"origin": [-3, 20.25, -9.5], "size": [6, 2, 7], "pivot": [0, 21, -6], "rotation": [9, 0, 0], "uv": [48, 12]},
+						{"origin": [-1.5, 16, -10], "size": [3, 4, 1], "uv": [48, 21]},
+						{"origin": [-4, 12, -9], "size": [8, 8, 4], "inflate": 0.2, "uv": [48, 0]},
+						{"origin": [-4, 12, -4.6], "size": [8, 8, 12], "inflate": 0.2, "uv": [0, 46]}
+					]
+				},
+				{
+					"name": "head",
+					"parent": "body",
+					"pivot": [0, 24, -7],
+					"cubes": [
+						{"origin": [-6, 29, -17], "size": [14, 2, 14], "pivot": [0, 26.25, -9], "rotation": [-36.36024, 38.84468, -24.78507], "uv": [0, 30]},
+						{"origin": [-5, 31, -14], "size": [10, 7, 10], "pivot": [0, 26.25, -9], "rotation": [-36.36024, 38.84468, -24.78507], "uv": [40, 46]},
+						{"origin": [-3, 38, -11], "size": [5, 6, 5], "pivot": [0, 26.25, -9], "rotation": [-36.36024, 38.84468, -24.78507], "uv": [56, 63]}
+					]
+				},
+				{
+					"name": "leftLeg",
+					"parent": "body",
+					"pivot": [0, 16, 4],
+					"cubes": [
+						{"origin": [-4, 0, 2], "size": [4, 12, 4], "inflate": 0.15, "uv": [56, 21]}
+					]
+				},
+				{
+					"name": "rightLeg",
+					"parent": "body",
+					"pivot": [0, 16, 4],
+					"cubes": [
+						{"origin": [0, 0, 2], "size": [4, 12, 4], "inflate": 0.15, "uv": [40, 63]}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_gir.geo.json
+++ b/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_gir.geo.json
@@ -1,0 +1,84 @@
+{
+	"format_version": "1.12.0",
+	"minecraft:geometry": [
+		{
+			"description": {
+				"identifier": "geometry.trixie_gir",
+				"texture_width": 64,
+				"texture_height": 64,
+				"visible_bounds_width": 2,
+				"visible_bounds_height": 3.5,
+				"visible_bounds_offset": [0, 1.25, 0]
+			},
+			"bones": [
+				{
+					"name": "body",
+					"pivot": [0, 0, 0],
+					"cubes": [
+						{"origin": [-4, 12, -4.5], "size": [8, 8, 12], "inflate": 0.25, "uv": [0, 0]},
+						{"origin": [-4, 12, -9], "size": [8, 8, 4], "inflate": 0.25, "uv": [32, 20]}
+					]
+				},
+				{
+					"name": "head",
+					"parent": "body",
+					"pivot": [0, 24, -7],
+					"cubes": [
+						{"origin": [-4, 22, -13], "size": [8, 8, 8], "inflate": 0.7, "uv": [0, 20]},
+						{"origin": [-1, 19.43143, -12], "size": [2, 3, 0], "pivot": [7.4, 22.43143, -15.29748], "rotation": [-20, 0, 0], "uv": [48, 16]}
+					]
+				},
+				{
+					"name": "ears",
+					"parent": "head",
+					"pivot": [0, 24, -7],
+					"cubes": [
+						{"origin": [-4, 30.8, -8], "size": [2, 2, 2], "inflate": 0.1, "uv": [40, 16]},
+						{"origin": [2, 30.8, -8], "size": [2, 2, 2], "inflate": 0.1, "uv": [40, 16], "mirror": true}
+					]
+				},
+				{
+					"name": "neck",
+					"parent": "body",
+					"pivot": [0, 24, -7],
+					"rotation": [9, 0, 0],
+					"cubes": [
+						{"origin": [-2, 19, -9.75], "size": [4, 4, 4], "inflate": 0.1, "uv": [32, 48]}
+					]
+				},
+				{
+					"name": "rightArm",
+					"parent": "body",
+					"pivot": [0, 16, -5],
+					"cubes": [
+						{"origin": [0, 0, -7], "size": [4, 12, 4], "inflate": 0.2, "uv": [32, 32]}
+					]
+				},
+				{
+					"name": "leftLeg",
+					"parent": "body",
+					"pivot": [0, 16, 4],
+					"cubes": [
+						{"origin": [-4, 0, 2], "size": [4, 12, 4], "inflate": 0.2, "uv": [16, 36]}
+					]
+				},
+				{
+					"name": "leftArm",
+					"parent": "body",
+					"pivot": [0, 16, -5],
+					"cubes": [
+						{"origin": [-4, 0, -7], "size": [4, 12, 4], "inflate": 0.2, "uv": [0, 36]}
+					]
+				},
+				{
+					"name": "rightLeg",
+					"parent": "body",
+					"pivot": [0, 16, 4],
+					"cubes": [
+						{"origin": [0, 0, 2], "size": [4, 12, 4], "inflate": 0.2, "uv": [40, 0]}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_magician.geo.json
+++ b/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_magician.geo.json
@@ -1,0 +1,36 @@
+{
+	"format_version": "1.12.0",
+	"minecraft:geometry": [
+		{
+			"description": {
+				"identifier": "geometry.trixie_magician",
+				"texture_width": 128,
+				"texture_height": 128,
+				"visible_bounds_width": 3,
+				"visible_bounds_height": 4.5,
+				"visible_bounds_offset": [0, 1.75, 0]
+			},
+			"bones": [
+				{
+					"name": "body",
+					"pivot": [0, 0, 0],
+					"cubes": [
+						{"origin": [-4, 7, -9], "size": [8, 14, 16], "inflate": 0.25, "uv": [0, 0]},
+						{"origin": [-3, 20.25, -9.5], "size": [6, 2, 7], "pivot": [0, 21, -6], "rotation": [9, 0, 0], "uv": [40, 46]},
+						{"origin": [-1.5, 17, -10], "size": [3, 4, 1], "uv": [48, 11]}
+					]
+				},
+				{
+					"name": "head",
+					"parent": "body",
+					"pivot": [0, 24, -7],
+					"cubes": [
+						{"origin": [-6, 29, -17], "size": [14, 2, 14], "pivot": [0, 26.25, -9], "rotation": [-36.36024, 38.84468, -24.78507], "uv": [0, 30]},
+						{"origin": [-5, 31, -14], "size": [10, 7, 10], "pivot": [0, 26.25, -9], "rotation": [-36.36024, 38.84468, -24.78507], "uv": [0, 46]},
+						{"origin": [-3, 38, -11], "size": [5, 6, 5], "pivot": [0, 26.25, -9], "rotation": [-36.36024, 38.84468, -24.78507], "uv": [48, 0]}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_schoolgirl.geo.json
+++ b/src/client/resources/assets/minelittleflawless/geo/clothing/trixie_schoolgirl.geo.json
@@ -1,0 +1,155 @@
+{
+	"format_version": "1.12.0",
+	"minecraft:geometry": [
+		{
+			"description": {
+				"identifier": "geometry.trixie_schoolgirl",
+				"texture_width": 64,
+				"texture_height": 64,
+				"visible_bounds_width": 3,
+				"visible_bounds_height": 3.5,
+				"visible_bounds_offset": [0, 1.25, 0]
+			},
+			"bones": [
+				{
+					"name": "body",
+					"pivot": [0, 0, 0],
+					"cubes": [
+						{
+							"origin": [-4, 12, -9],
+							"size": [8, 8, 4],
+							"inflate": 0.1,
+							"uv": {
+								"north": {"uv": [4, 24], "uv_size": [8, 8]},
+								"east": {"uv": [0, 24], "uv_size": [4, 8]},
+								"south": {"uv": [16, 24], "uv_size": [8, 8]},
+								"west": {"uv": [12, 24], "uv_size": [4, 8]},
+								"up": {"uv": [4, 20], "uv_size": [8, 4]},
+								"down": {"uv": [12, 24], "uv_size": [8, -4]}
+							}
+						},
+						{
+							"origin": [-4, 12, -4.8],
+							"size": [8, 8, 12],
+							"inflate": 0.1,
+							"uv": {
+								"north": {"uv": [12, 12], "uv_size": [8, 8]},
+								"east": {"uv": [0, 12], "uv_size": [12, 8]},
+								"south": {"uv": [32, 12], "uv_size": [8, 8]},
+								"west": {"uv": [20, 12], "uv_size": [12, 8]},
+								"up": {"uv": [12, 0], "uv_size": [8, 12]},
+								"down": {"uv": [20, 12], "uv_size": [8, -12]}
+							}
+						},
+						{
+							"origin": [-3, 19.1, -10],
+							"size": [6, 2, 5],
+							"uv": {
+								"north": {"uv": [45, 5], "uv_size": [6, 2]},
+								"east": {"uv": [40, 5], "uv_size": [5, 2]},
+								"south": {"uv": [56, 5], "uv_size": [6, 2]},
+								"west": {"uv": [51, 5], "uv_size": [5, 2]},
+								"up": {"uv": [45, 0], "uv_size": [6, 5]},
+								"down": {"uv": [51, 5], "uv_size": [6, -5]}
+							}
+						},
+						{
+							"origin": [-1, 13, -9.25],
+							"size": [2, 6, 0],
+							"pivot": [0.1, 19.1, -9.35],
+							"rotation": [-3.75, 0, 0],
+							"uv": {
+								"north": {"uv": [40, 7], "uv_size": [2, 6]},
+								"east": {"uv": [40, 7], "uv_size": [0, 6]},
+								"south": {"uv": [42, 7], "uv_size": [2, 6]},
+								"west": {"uv": [42, 7], "uv_size": [0, 6]},
+								"up": {"uv": [40, 7], "uv_size": [2, 0]},
+								"down": {"uv": [42, 7], "uv_size": [2, 0]}
+							}
+						}
+					]
+				},
+				{
+					"name": "rightArm",
+					"parent": "body",
+					"pivot": [0, 16, -5],
+					"cubes": [
+						{
+							"origin": [0, 0, -7],
+							"size": [4, 12, 4],
+							"inflate": 0.05,
+							"uv": {
+								"north": {"uv": [28, 24], "uv_size": [4, 12]},
+								"east": {"uv": [24, 24], "uv_size": [4, 12]},
+								"south": {"uv": [36, 24], "uv_size": [4, 12]},
+								"west": {"uv": [32, 24], "uv_size": [4, 12]},
+								"up": {"uv": [28, 20], "uv_size": [4, 4]},
+								"down": {"uv": [32, 24], "uv_size": [4, -4]}
+							}
+						}
+					]
+				},
+				{
+					"name": "leftLeg",
+					"parent": "body",
+					"pivot": [0, 16, 4],
+					"cubes": [
+						{
+							"origin": [-4, 0, 2],
+							"size": [4, 12, 4],
+							"inflate": 0.05,
+							"uv": {
+								"north": {"uv": [20, 40], "uv_size": [4, 12]},
+								"east": {"uv": [16, 40], "uv_size": [4, 12]},
+								"south": {"uv": [28, 40], "uv_size": [4, 12]},
+								"west": {"uv": [24, 40], "uv_size": [4, 12]},
+								"up": {"uv": [20, 36], "uv_size": [4, 4]},
+								"down": {"uv": [24, 40], "uv_size": [4, -4]}
+							}
+						}
+					]
+				},
+				{
+					"name": "leftArm",
+					"parent": "body",
+					"pivot": [0, 16, -5],
+					"cubes": [
+						{
+							"origin": [-4, 0, -7],
+							"size": [4, 12, 4],
+							"inflate": 0.05,
+							"uv": {
+								"north": {"uv": [4, 36], "uv_size": [4, 12]},
+								"east": {"uv": [0, 36], "uv_size": [4, 12]},
+								"south": {"uv": [12, 36], "uv_size": [4, 12]},
+								"west": {"uv": [8, 36], "uv_size": [4, 12]},
+								"up": {"uv": [4, 32], "uv_size": [4, 4]},
+								"down": {"uv": [8, 36], "uv_size": [4, -4]}
+							}
+						}
+					]
+				},
+				{
+					"name": "rightLeg",
+					"parent": "body",
+					"pivot": [0, 16, 4],
+					"cubes": [
+						{
+							"origin": [0, 0, 2],
+							"size": [4, 12, 4],
+							"inflate": 0.05,
+							"uv": {
+								"north": {"uv": [36, 40], "uv_size": [4, 12]},
+								"east": {"uv": [32, 40], "uv_size": [4, 12]},
+								"south": {"uv": [44, 40], "uv_size": [4, 12]},
+								"west": {"uv": [40, 40], "uv_size": [4, 12]},
+								"up": {"uv": [36, 36], "uv_size": [4, 4]},
+								"down": {"uv": [40, 40], "uv_size": [4, -4]}
+							}
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_black_magician.png
+++ b/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_black_magician.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abad2bf917fdf4c3f7f9ffec351b44c214003ec01ca5e410ea99423cd0481991
+size 2347

--- a/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_gir.png
+++ b/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_gir.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2432f15ef5a36b6b94b621fbbeeaad0da8c0534ede1794c8beab41e50406c4a
+size 1408

--- a/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_magician.png
+++ b/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_magician.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81fb52a451d08d87adb4083244fa023509da31b89aab80c9c6fd917fe472e691
+size 2375

--- a/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_schoolgirl.png
+++ b/src/client/resources/assets/minelittleflawless/textures/entities/clothing/trixie_schoolgirl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d52f112becd840f7bc8c9cac10eaca13a4058fb5c56e831dde4bf5f95c8b452
+size 880

--- a/src/main/java/org/projectflawless/minelittleflawless/Clothing.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/Clothing.java
@@ -4,10 +4,18 @@ import net.minecraft.resources.ResourceLocation;
 
 public class Clothing {
     public static ResourceLocation NONE = new ResourceLocation(MineLittleFlawless.MOD_ID, "none");
+
+    // Flawless clothing
     public static ResourceLocation FLAWLESS_MAGICIAN_CLOTHING = new ResourceLocation(MineLittleFlawless.MOD_ID, "flawless_magician_clothing");
     public static ResourceLocation TUXEDO = new ResourceLocation(MineLittleFlawless.MOD_ID, "tuxedo");
     public static ResourceLocation FARMER = new ResourceLocation(MineLittleFlawless.MOD_ID, "farmer");
     public static ResourceLocation PAJAMAS = new ResourceLocation(MineLittleFlawless.MOD_ID, "pajamas");
     public static ResourceLocation SCHOOLGIRL = new ResourceLocation(MineLittleFlawless.MOD_ID, "schoolgirl");
     public static ResourceLocation ROCKSTAR = new ResourceLocation(MineLittleFlawless.MOD_ID, "rockstar");
+
+    // Trixie clothing
+    public static ResourceLocation TRIXIE_MAGICIAN = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixie_magician");
+    public static ResourceLocation TRIXIE_BLACK_MAGICIAN = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixie_black_magician");
+    public static ResourceLocation TRIXIE_GIR = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixie_gir");
+    public static ResourceLocation TRIXIE_SCHOOLGIRL = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixie_schoolgirl");
 }

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Flawless.java
@@ -34,9 +34,6 @@ import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.network.syncher.SynchedEntityData;
-import net.minecraft.network.syncher.EntityDataSerializers;
-import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.sounds.SoundEvents;
@@ -49,8 +46,6 @@ import java.util.Comparator;
 import java.util.Objects;
 
 public class Flawless extends TamableTamersPony implements Shearable {
-	public static final EntityDataAccessor<String> DATA_CLOTHING = SynchedEntityData.defineId(Flawless.class, EntityDataSerializers.STRING);
-
     public Flawless(EntityType<Flawless> type, Level world) {
 		super(type, world);
 		xpReward = 0;
@@ -58,12 +53,6 @@ public class Flawless extends TamableTamersPony implements Shearable {
         this.setGuaranteedDrop(EquipmentSlot.CHEST);
         this.setUnicorn(true);
     }
-
-	@Override
-	protected void defineSynchedData() {
-		super.defineSynchedData();
-		this.entityData.define(DATA_CLOTHING, Clothing.NONE.toString());
-	}
 
 	@Override
 	protected void registerGoals() {
@@ -126,21 +115,6 @@ public class Flawless extends TamableTamersPony implements Shearable {
         this.setClothing(flawlessClothing);
 
 		return retval;
-	}
-
-	@Override
-	public void addAdditionalSaveData(CompoundTag compound) {
-		super.addAdditionalSaveData(compound);
-		compound.putString("clothing", this.entityData.get(DATA_CLOTHING));
-	}
-
-	@Override
-	public void readAdditionalSaveData(CompoundTag compound) {
-		super.readAdditionalSaveData(compound);
-
-        if (compound.contains("clothing")) {
-            this.entityData.set(DATA_CLOTHING, compound.getString("clothing"));
-        }
 	}
 
 	@Override
@@ -318,13 +292,5 @@ public class Flawless extends TamableTamersPony implements Shearable {
     @Override
     public boolean readyForShearing() {
         return !this.getClothing().equals(Clothing.NONE);
-    }
-
-    public ResourceLocation getClothing() {
-        return new ResourceLocation(this.getEntityData().get(DATA_CLOTHING));
-    }
-
-    public void setClothing(ResourceLocation clothing) {
-        this.getEntityData().set(DATA_CLOTHING, clothing.toString());
     }
 }

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/TamableTamersPony.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/TamableTamersPony.java
@@ -4,6 +4,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityType;
@@ -22,6 +23,7 @@ import net.minecraft.world.entity.raid.Raider;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.constant.DefaultAnimations;
@@ -33,6 +35,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 
 public abstract class TamableTamersPony extends TamableAnimal implements GeoEntity {
     private final AnimatableInstanceCache geoCache = GeckoLibUtil.createInstanceCache(this);
+    private static final EntityDataAccessor<String> DATA_CLOTHING = SynchedEntityData.defineId(TamableTamersPony.class, EntityDataSerializers.STRING);
     private static final EntityDataAccessor<Boolean> IS_STALLION = SynchedEntityData.defineId(TamableTamersPony.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Boolean> IS_UNICORN = SynchedEntityData.defineId(TamableTamersPony.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Boolean> IS_PEGASUS = SynchedEntityData.defineId(TamableTamersPony.class, EntityDataSerializers.BOOLEAN);
@@ -58,6 +61,7 @@ public abstract class TamableTamersPony extends TamableAnimal implements GeoEnti
     @Override
     protected void defineSynchedData() {
         super.defineSynchedData();
+        this.getEntityData().define(DATA_CLOTHING, Clothing.NONE.toString());
         this.getEntityData().define(IS_STALLION, false);
         this.getEntityData().define(IS_UNICORN, false);
         this.getEntityData().define(IS_PEGASUS, false);
@@ -66,6 +70,8 @@ public abstract class TamableTamersPony extends TamableAnimal implements GeoEnti
     @Override
     public void addAdditionalSaveData(CompoundTag compound) {
         super.addAdditionalSaveData(compound);
+
+        compound.putString("clothing", this.getClothing().toString());
 
         CompoundTag ponyData = new CompoundTag();
         ponyData.putBoolean("Stallion", this.isStallion());
@@ -78,12 +84,23 @@ public abstract class TamableTamersPony extends TamableAnimal implements GeoEnti
     public void readAdditionalSaveData(CompoundTag compound) {
         super.readAdditionalSaveData(compound);
 
+        if (compound.contains("clothing"))
+            this.setClothing(ResourceLocation.tryParse(compound.getString("clothing")));
+
         if (compound.contains("PonyData")) {
             CompoundTag ponyData = compound.getCompound("PonyData");
             this.setStallion(ponyData.getBoolean("Stallion"));
             this.setUnicorn(ponyData.getBoolean("Unicorn"));
             this.setPegasus(ponyData.getBoolean("Pegasus"));
         }
+    }
+
+    public ResourceLocation getClothing() {
+        return ResourceLocation.tryParse(this.getEntityData().get(DATA_CLOTHING));
+    }
+
+    public void setClothing(ResourceLocation clothing) {
+        this.getEntityData().set(DATA_CLOTHING, clothing.toString());
     }
 
     public boolean isStallion() {

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Trixie.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Trixie.java
@@ -1,7 +1,11 @@
 package org.projectflawless.minelittleflawless.entity;
 
+import net.minecraft.Util;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.goal.*;
@@ -10,11 +14,17 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ServerLevelAccessor;
+import org.jetbrains.annotations.Nullable;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
 
 public class Trixie extends TamableTamersPony {
+    public static final ResourceLocation[] CLOTHING_TYPES = { Clothing.NONE, Clothing.TRIXIE_MAGICIAN,
+            Clothing.TRIXIE_BLACK_MAGICIAN, Clothing.TRIXIE_GIR, Clothing.TRIXIE_SCHOOLGIRL };
+
     public Trixie(EntityType<Trixie> type, Level world) {
         super(type, world);
         this.setUnicorn(true);
@@ -44,6 +54,14 @@ public class Trixie extends TamableTamersPony {
     @Override
     public SoundEvent getDeathSound() {
         return MineLittleFlawlessSoundEvents.TRIXIE_DEATH;
+    }
+
+    @Override
+    public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType reason, @Nullable SpawnGroupData spawnData, @Nullable CompoundTag dataTag) {
+        ResourceLocation randomClothing = Util.getRandom(CLOTHING_TYPES, this.getRandom());
+        this.setClothing(randomClothing);
+
+        return super.finalizeSpawn(level, difficulty, reason, spawnData, dataTag);
     }
 
     @Override


### PR DESCRIPTION
Trixie now wears 4 clothes: Magician, Black Magician, Gir and Schoolgirl. They do not have side effects unlike Flawless.

For now, Trixie's clothes does not have a crafting recipe and that they cannot be unequipped. However, I will see if I can make a block/mob that gives clothes to you.

Lastly, the clothing NBT will be used for all ponies instead of just Flawless since multiple ponies (starting with Trixie) will now have their own swappable clothing.

This will effectively close #78, but I will add more clothing in the future that I may have missed.