### PR TITLE
Add new spawn categories for the ponies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,10 @@ loom {
     runs {
         client {
             programArgs(["--username", "Dev"])
-        }
+            vmArg "-Dmixin.debug.export=true"        }
     }
 
+    accessWidenerPath = file("src/main/resources/minelittleflawless.classtweaker")
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,8 @@ org.gradle.configuration-cache=false
 # check these on https://fabricmc.net/develop
 minecraft_version=1.20.1
 parchment_mappings=2023.09.03
-loader_version=0.18.4
-loom_version=1.15-SNAPSHOT
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/projectflawless/minelittleflawless/init/MineLittleFlawlessBiomeSpawns.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/init/MineLittleFlawlessBiomeSpawns.java
@@ -10,9 +10,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Flawless
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> true,
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.FLAWLESS,
-                20,
+                1,
                 4,
                 4
         );
@@ -20,9 +20,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Twilight
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> true,
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.TWILIGHT,
-                20,
+                1,
                 4,
                 4
         );
@@ -30,9 +30,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Trixie
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> true,
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.TRIXIE,
-                20,
+                1,
                 4,
                 4
         );
@@ -40,16 +40,16 @@ public class MineLittleFlawlessBiomeSpawns {
         // Arinos - Overworld
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.hasTag(BiomeTags.IS_OVERWORLD),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.ARINOS,
-                95,
+                8,
                 4,
                 4);
 
         // Arinos - End
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.hasTag(BiomeTags.IS_END),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.ARINOS,
                 1,
                 4,
@@ -59,9 +59,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Arinos - Basalt Deltas
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.getBiomeKey().equals(Biomes.BASALT_DELTAS),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.ARINOS,
-                26,
+                1,
                 4,
                 4
         );
@@ -69,9 +69,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Arinos - Crimson Forest
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.getBiomeKey().equals(Biomes.CRIMSON_FOREST),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.ARINOS,
-                3,
+                8,
                 4,
                 4
         );
@@ -79,9 +79,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Arinos - Nether Wastes
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.getBiomeKey().equals(Biomes.NETHER_WASTES),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.ARINOS,
-                31,
+                1,
                 4,
                 4
         );
@@ -89,9 +89,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Arinos - Soul Sand Valley
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.getBiomeKey().equals(Biomes.SOUL_SAND_VALLEY),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.ARINOS,
-                13,
+                1,
                 4,
                 4
         );
@@ -99,9 +99,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Arinos - Warped Forest
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.getBiomeKey().equals(Biomes.WARPED_FOREST),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.ARINOS,
-                1,
+                8,
                 1,
                 4
         );
@@ -109,9 +109,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Trixiebelle
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.hasTag(MineLittleFlawlessTags.SPAWNS_TRIXIEBELLE),
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.TRIXIEBELLE,
-                20,
+                1,
                 4,
                 4
         );
@@ -119,9 +119,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Skywishes
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.hasTag(MineLittleFlawlessTags.SPAWNS_SKYWISHES),
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.SKYWISHES,
-                20,
+                1,
                 4,
                 4
         );
@@ -129,9 +129,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Star Catcher
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.hasTag(MineLittleFlawlessTags.SPAWNS_STAR_CATCHER),
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.STAR_CATCHER,
-                20,
+                1,
                 4,
                 4
         );
@@ -139,9 +139,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Marionette
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.hasTag(MineLittleFlawlessTags.SPAWNS_MARIONETTE),
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.MARIONETTE,
-                20,
+                1,
                 4,
                 4
         );
@@ -149,9 +149,9 @@ public class MineLittleFlawlessBiomeSpawns {
         // Jackie Spectre
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> biomeSelectionContext.hasTag(MineLittleFlawlessTags.SPAWNS_JACKIE_SPECTRE),
-                MobCategory.CREATURE,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT,
                 MineLittleFlawlessEntities.JACKIE_SPECTRE,
-                20,
+                1,
                 4,
                 4
         );
@@ -159,16 +159,16 @@ public class MineLittleFlawlessBiomeSpawns {
         // Wish Fulfillment - Overworld
         BiomeModifications.addSpawn(
                 biomeSelectionContext -> true,
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.WISH_FULFILLMENT,
-                20,
+                1,
                 4,
                 4
         );
 
         // Wish Fulfillment - Warped Forest
         BiomeModifications.addSpawn(biomeSelectionContext -> biomeSelectionContext.getBiomeKey().equals(Biomes.WARPED_FOREST),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.WISH_FULFILLMENT,
                 1,
                 1,
@@ -177,9 +177,9 @@ public class MineLittleFlawlessBiomeSpawns {
 
         // Wish Fulfillment - Crimson Forest
         BiomeModifications.addSpawn(biomeSelectionContext -> biomeSelectionContext.getBiomeKey().equals(Biomes.CRIMSON_FOREST),
-                MobCategory.MONSTER,
+                MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT,
                 MineLittleFlawlessEntities.WISH_FULFILLMENT,
-                3,
+                1,
                 4,
                 4
         );

--- a/src/main/java/org/projectflawless/minelittleflawless/init/MineLittleFlawlessEntities.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/init/MineLittleFlawlessEntities.java
@@ -18,61 +18,61 @@ public class MineLittleFlawlessEntities {
 					.sized(0.75f, 3.125f));
 
     public static final EntityType<Flawless> FLAWLESS = register("flawless",
-			EntityType.Builder.of(Flawless::new, MobCategory.CREATURE)
+			EntityType.Builder.of(Flawless::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
 					.sized(0.8125f, 2f));
 
     public static final EntityType<Twilight> TWILIGHT = register("twilight",
-            EntityType.Builder.of(Twilight::new, MobCategory.CREATURE)
+            EntityType.Builder.of(Twilight::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.8125f, 2f));
 
     public static final EntityType<Trixie> TRIXIE = register("trixie",
-            EntityType.Builder.of(Trixie::new, MobCategory.CREATURE)
+            EntityType.Builder.of(Trixie::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.8125f, 2f));
 
     public static final EntityType<Arinos> ARINOS = register("arinos",
-            EntityType.Builder.of(Arinos::new, MobCategory.MONSTER)
+            EntityType.Builder.of(Arinos::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.8125f, 2f));
 
     public static final EntityType<Trixiebelle> TRIXIEBELLE = register("trixiebelle",
-            EntityType.Builder.of(Trixiebelle::new, MobCategory.CREATURE)
+            EntityType.Builder.of(Trixiebelle::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.56875f, 1.4f));
 
     public static final EntityType<Skywishes> SKYWISHES = register("skywishes",
-            EntityType.Builder.of(Skywishes::new, MobCategory.CREATURE)
+            EntityType.Builder.of(Skywishes::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.56875f, 1.4f));
 
     public static final EntityType<StarCatcher> STAR_CATCHER = register("star_catcher",
-            EntityType.Builder.of(StarCatcher::new, MobCategory.CREATURE)
+            EntityType.Builder.of(StarCatcher::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(1.178125f, 2.9f));
 
     public static final EntityType<Marionette> MARIONETTE = register("marionette",
-            EntityType.Builder.of(Marionette::new, MobCategory.CREATURE)
+            EntityType.Builder.of(Marionette::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.8125f, 2f));
 
     public static final EntityType<JackieSpectre> JACKIE_SPECTRE = register("jackie_spectre",
-            EntityType.Builder.of(JackieSpectre::new, MobCategory.CREATURE)
+            EntityType.Builder.of(JackieSpectre::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.56875f, 1.4f));
 
     public static final EntityType<WishFulfillment> WISH_FULFILLMENT = register("wish_fulfillment",
-            EntityType.Builder.of(WishFulfillment::new, MobCategory.MONSTER)
+            EntityType.Builder.of(WishFulfillment::new, MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT)
                     .clientTrackingRange(64)
                     .updateInterval(3)
                     .sized(0.8125f, 2f));

--- a/src/main/java/org/projectflawless/minelittleflawless/mixin/MobCategoryMixin.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/mixin/MobCategoryMixin.java
@@ -1,0 +1,16 @@
+package org.projectflawless.minelittleflawless.mixin;
+
+import net.minecraft.world.entity.MobCategory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(MobCategory.class)
+enum MobCategoryMixin {
+    MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT("minelittleflawless_mlp_persistent", 10, true, true, 128),
+    MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT("minelittleflawless_mlp_non_persistent", 35, true, false, 128);
+
+    @Shadow
+    MobCategoryMixin(String name, int max, boolean isFriendly, boolean isPersistent, int despawnDistance) {
+
+    }
+}

--- a/src/main/java/org/projectflawless/minelittleflawless/mixin/NaturalSpawnerMixin.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/mixin/NaturalSpawnerMixin.java
@@ -1,0 +1,38 @@
+package org.projectflawless.minelittleflawless.mixin;
+
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import net.minecraft.core.Holder;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.NaturalSpawner;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(NaturalSpawner.class)
+final class NaturalSpawnerMixin {
+    @WrapMethod(method = "spawnMobsForChunkGeneration")
+    private static void spawnWithModdedMobsForChunkGeneration(ServerLevelAccessor levelAccessor, Holder<Biome> biome, ChunkPos chunkPos, RandomSource random, Operation<Void> original, @Share("mobCategory") LocalRef<MobCategory> mobCategoryLocalRef) {
+        mobCategoryLocalRef.set(MobCategory.CREATURE);
+        original.call(levelAccessor, biome, chunkPos, random);
+
+        mobCategoryLocalRef.set(MobCategory.MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT);
+        original.call(levelAccessor, biome, chunkPos, random);
+    }
+
+    @ModifyArg(
+            method = "spawnMobsForChunkGeneration",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/biome/MobSpawnSettings;getMobs(Lnet/minecraft/world/entity/MobCategory;)Lnet/minecraft/util/random/WeightedRandomList;"),
+            index = 0
+    )
+    private static MobCategory supportMobCategoryArgumentForModdedCategories(MobCategory mobCategory, @Share("mobCategory") LocalRef<MobCategory> mobCategoryLocalRef) {
+        return mobCategoryLocalRef.get();
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
 		]
 	},
 	"depends": {
-		"fabricloader": ">=0.18.4",
+		"fabricloader": ">=${loader_version}",
 		"minecraft": "~1.20.1",
 		"java": ">=17",
 		"fabric-api": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,5 +36,9 @@
 		"fabric-api": "*",
         "smartbrainlib": ">=1.15",
         "geckolib": ">=4.8.4"
-	}
+	},
+    "mixins": [
+      "minelittleflawless.mixins.json"
+    ],
+    "accessWidener": "minelittleflawless.classtweaker"
 }

--- a/src/main/resources/minelittleflawless.classtweaker
+++ b/src/main/resources/minelittleflawless.classtweaker
@@ -1,0 +1,4 @@
+classTweaker v2 named
+
+transitive-extend-enum net/minecraft/world/entity/MobCategory MINE_LITTLE_FLAWLESS_FABRIC_MLP_PERSISTENT
+transitive-extend-enum net/minecraft/world/entity/MobCategory MINE_LITTLE_FLAWLESS_FABRIC_MLP_NON_PERSISTENT

--- a/src/main/resources/minelittleflawless.mixins.json
+++ b/src/main/resources/minelittleflawless.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "org.projectflawless.minelittleflawless.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "overwrites": {
+    "requireAnnotations": true
+  },
+  "mixins": [
+    "MobCategoryMixin",
+    "NaturalSpawnerMixin"
+  ]
+}


### PR DESCRIPTION
## Add new spawn categories for the ponies
* Added a new spawn category called MLP Persistent for chunk loading ponies. Cap is 10.

* Added as well a new spawn category called MLP Non-Persistent for ponies that spawn but do not stay as persistent (unless satisfied by specific conditions).

## Bump Gradle version
* Bumped Gradle version to 9.5.0

## Bump Fabric Loader and Fabric Loom versions
* Bumped Fabric Loader to 0.19.3.

* Bumped Fabric Loom to 1.17-SNAPSHOT.

Closes #83.