### PR TITLE
Set every pony's single-use clothing to the NBT clothing system

### DIFF
--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/JesterLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/JesterLayer.java
@@ -1,12 +1,25 @@
 package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.client.model.entity.ArinosModel;
 import org.projectflawless.minelittleflawless.client.model.entity.clothing.JesterModel;
 import org.projectflawless.minelittleflawless.client.renderer.entity.ArinosRenderer;
 import org.projectflawless.minelittleflawless.entity.Arinos;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
 
 public class JesterLayer extends ClothingLayer<Arinos, ArinosModel> {
     public JesterLayer(ArinosRenderer renderer) {
         super(renderer, new JesterModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, Arinos animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.JESTER)) {
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+        }
     }
 }

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/MaidLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/MaidLayer.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.client.model.entity.StarCatcherModel;
 import org.projectflawless.minelittleflawless.client.model.entity.clothing.MaidModel;
 import org.projectflawless.minelittleflawless.client.renderer.entity.StarCatcherRenderer;
@@ -17,7 +18,7 @@ public class MaidLayer extends ClothingLayer<StarCatcher, StarCatcherModel> {
 
     @Override
     public void render(PoseStack poseStack, StarCatcher animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
-        if (animatable.canPickUpLoot()) {
+        if (animatable.getClothing().equals(Clothing.MAID)) {
             super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
         }
     }

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/MaskLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/MaskLayer.java
@@ -1,12 +1,25 @@
 package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.client.model.entity.MarionetteModel;
 import org.projectflawless.minelittleflawless.client.model.entity.clothing.MaskModel;
 import org.projectflawless.minelittleflawless.client.renderer.entity.MarionetteRenderer;
 import org.projectflawless.minelittleflawless.entity.Marionette;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
 
 public class MaskLayer extends ClothingLayer<Marionette, MarionetteModel> {
     public MaskLayer(MarionetteRenderer renderer) {
         super(renderer, new MaskModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, Marionette animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.MASK)) {
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+        }
     }
 }

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/SailorLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/SailorLayer.java
@@ -1,12 +1,25 @@
 package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.client.model.entity.JackieSpectreModel;
 import org.projectflawless.minelittleflawless.client.model.entity.clothing.SailorModel;
 import org.projectflawless.minelittleflawless.client.renderer.entity.JackieSpectreRenderer;
 import org.projectflawless.minelittleflawless.entity.JackieSpectre;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
 
 public class SailorLayer extends ClothingLayer<JackieSpectre, JackieSpectreModel> {
     public SailorLayer(JackieSpectreRenderer renderer) {
         super(renderer, new SailorModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, JackieSpectre animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.SAILOR)) {
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+        }
     }
 }

--- a/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixiebelleJesterLayer.java
+++ b/src/client/java/org/projectflawless/minelittleflawless/client/renderer/entity/layers/TrixiebelleJesterLayer.java
@@ -1,12 +1,25 @@
 package org.projectflawless.minelittleflawless.client.renderer.entity.layers;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.client.model.entity.TrixiebelleModel;
 import org.projectflawless.minelittleflawless.client.model.entity.clothing.TrixiebelleJesterModel;
 import org.projectflawless.minelittleflawless.client.renderer.entity.TrixiebelleRenderer;
 import org.projectflawless.minelittleflawless.entity.Trixiebelle;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
 
 public class TrixiebelleJesterLayer extends ClothingLayer<Trixiebelle, TrixiebelleModel> {
     public TrixiebelleJesterLayer(TrixiebelleRenderer renderer) {
         super(renderer, new TrixiebelleJesterModel());
+    }
+
+    @Override
+    public void render(PoseStack poseStack, Trixiebelle animatable, BakedGeoModel bakedModel, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (animatable.getClothing().equals(Clothing.TRIXIEBELLE_JESTER)) {
+            super.render(poseStack, animatable, bakedModel, renderType, bufferSource, buffer, partialTick, packedLight, packedOverlay);
+        }
     }
 }

--- a/src/main/java/org/projectflawless/minelittleflawless/Clothing.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/Clothing.java
@@ -18,4 +18,19 @@ public class Clothing {
     public static ResourceLocation TRIXIE_BLACK_MAGICIAN = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixie_black_magician");
     public static ResourceLocation TRIXIE_GIR = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixie_gir");
     public static ResourceLocation TRIXIE_SCHOOLGIRL = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixie_schoolgirl");
+
+    // Arinos clothing
+    public static ResourceLocation JESTER = new ResourceLocation(MineLittleFlawless.MOD_ID, "jester");
+
+    // Marionette clothing
+    public static ResourceLocation MASK = new ResourceLocation(MineLittleFlawless.MOD_ID, "mask");
+
+    // Trixiebelle clothing
+    public static ResourceLocation TRIXIEBELLE_JESTER = new ResourceLocation(MineLittleFlawless.MOD_ID, "trixiebelle_jester");
+
+    // Star Catcher Clothing
+    public static ResourceLocation MAID = new ResourceLocation(MineLittleFlawless.MOD_ID, "maid");
+
+    // Jackie Spectre clothing
+    public static ResourceLocation SAILOR = new ResourceLocation(MineLittleFlawless.MOD_ID, "sailor");
 }

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Arinos.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Arinos.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.state.BlockState;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 
@@ -19,6 +20,7 @@ public class Arinos extends TamableTamersPony {
     public Arinos(EntityType<Arinos> type, Level world) {
         super(type, world);
         this.setAlicorn(true);
+        this.setClothing(Clothing.JESTER);
     }
 
     @Override

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/JackieSpectre.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/JackieSpectre.java
@@ -12,12 +12,14 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 
 public class JackieSpectre extends TamableTamersPony {
     public JackieSpectre(EntityType<JackieSpectre> type, Level world) {
         super(type, world);
+        this.setClothing(Clothing.SAILOR);
     }
 
     @Override

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Marionette.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Marionette.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
@@ -19,6 +20,7 @@ import org.projectflawless.minelittleflawless.init.MineLittleFlawlessTags;
 public class Marionette extends TamableTamersPony {
     public Marionette(EntityType<Marionette> type, Level world) {
         super(type, world);
+        this.setClothing(Clothing.MASK);
     }
 
     @Override

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/StarCatcher.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/StarCatcher.java
@@ -96,21 +96,6 @@ public class StarCatcher extends TamableTamersPony implements InventoryCarrier, 
     }
 
     @Override
-    public boolean canPickUpLoot() {
-        if (this.level().isClientSide()) {
-            return this.getEntityData().get(CLEAN_DATA_ID);
-        } else {
-            return super.canPickUpLoot();
-        }
-    }
-
-    @Override
-    public void setCanPickUpLoot(boolean canPickUpLoot) {
-        this.getEntityData().set(CLEAN_DATA_ID, canPickUpLoot);
-        super.setCanPickUpLoot(canPickUpLoot);
-    }
-
-    @Override
     public boolean wantsToPickUp(ItemStack stack) {
         // True if her inventory is not full and she can pick up through cleaning mode.
         return this.inventory.canAddItem(stack);

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/StarCatcher.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/StarCatcher.java
@@ -34,6 +34,7 @@ import net.tslat.smartbrainlib.api.core.sensor.vanilla.NearbyPlayersSensor;
 import net.tslat.smartbrainlib.api.core.sensor.vanilla.NearestItemSensor;
 import net.tslat.smartbrainlib.util.BrainUtils;
 import org.jetbrains.annotations.Nullable;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.entity.ai.behavior.GoAndThrowItems;
 import org.projectflawless.minelittleflawless.entity.ai.behavior.GoToWantedItem;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
@@ -240,6 +241,12 @@ public class StarCatcher extends TamableTamersPony implements InventoryCarrier, 
             player1.broadcastBreakEvent(hand);
             this.setCanPickUpLoot(false);
         });
+
+        if (toggle) {
+            this.setClothing(Clothing.MAID);
+        } else {
+            this.setClothing(Clothing.NONE);
+        }
     }
 
     private static Optional<PositionTracker> trackTarget(StarCatcher starCatcher) {

--- a/src/main/java/org/projectflawless/minelittleflawless/entity/Trixiebelle.java
+++ b/src/main/java/org/projectflawless/minelittleflawless/entity/Trixiebelle.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
+import org.projectflawless.minelittleflawless.Clothing;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessEntities;
 import org.projectflawless.minelittleflawless.init.MineLittleFlawlessSoundEvents;
 
@@ -19,6 +20,7 @@ public class Trixiebelle extends TamableTamersPony {
     public Trixiebelle(EntityType<Trixiebelle> type, Level world) {
         super(type, world);
         this.setUnicorn(true);
+        this.setClothing(Clothing.TRIXIEBELLE_JESTER);
     }
 
     @Override


### PR DESCRIPTION
## Set every pony's single-use clothing to the NBT clothing system
* Set Arinos, Star Catcher, Marionette, Jackie Spectre, and Trixiebelle's single use clothing to the NBT clothing system (the `clothing` NBT key).

## Remove Star Catcher's overridden canPickupLoot and setCanPickupLoot methods
* The reason for their removal is that Star Catcher's Maid layer already tracks for the `clothing` NBT system, which is set to `minelittleflawless:maid` when she starts to do maid mode, and `minelittleflawless:none` otherwise. She spawns without maid clothes by default.

Closes #84.